### PR TITLE
Work around the exception raised when a base path doesn't exist

### DIFF
--- a/fsal/fsdbmanager.py
+++ b/fsal/fsdbmanager.py
@@ -83,7 +83,10 @@ class FSDBManager(object):
                            for path in config['fsal.basepaths']]
         if not self.base_paths:
             raise RuntimeError('No base paths specified.')
-
+        # make sure base paths exist
+        for path in self.base_paths:
+            if not os.path.exists(path):
+                os.makedirs(path)
         logging.debug(u'Using basepaths: %s', ', '.join(self.base_paths))
         self.db = context['databases'].fs
         self.bundles_dir = config['bundles.bundles_dir']


### PR DESCRIPTION
This fix is not 100% guaranteed to be proper, but it solved the issue at
the moment. It should be confirmed whether such approach is acceptable,
and if not, what should be done. `FSDBManager.get_root_dir` raises an
exception when the folder it tries to access doesn't exist, which is a
possibility in case of chroots.
